### PR TITLE
Adding better error-handling to the vCloud Air resource fetchers.

### DIFF
--- a/lib/kitchen/driver/vcair.rb
+++ b/lib/kitchen/driver/vcair.rb
@@ -191,35 +191,47 @@ module Kitchen
       end
 
       def image
-        if config[:image_id]
-          catalog.catalog_items.get(config[:image_id])
-        else
-          catalog.catalog_items.get_by_name(config[:image_name])
-        end
+        image = if config[:image_id]
+                  catalog.catalog_items.get(config[:image_id])
+                else
+                  catalog.catalog_items.get_by_name(config[:image_name])
+                end
+
+        raise 'Unable to find image - check your image_id or image_name' if image.nil?
+        image
       end
 
       def catalog
-        if config[:catalog_id]
-          org.catalogs.get(config[:catalog_id])
-        else
-          org.catalogs.get_by_name(config[:catalog_name])
-        end
+        catalog = if config[:catalog_id]
+                    org.catalogs.get(config[:catalog_id])
+                  else
+                    org.catalogs.get_by_name(config[:catalog_name])
+                  end
+
+        raise 'Unable to find catalog - check your catalog_id or catalog_name' if catalog.nil?
+        catalog
       end
 
       def vdc
-        if config[:vdc_id]
-          org.vdcs.get(config[:vdc_id])
-        else
-          org.vdcs.get_by_name(config[:vdc_name])
-        end
+        vdc = if config[:vdc_id]
+                org.vdcs.get(config[:vdc_id])
+              else
+                org.vdcs.get_by_name(config[:vdc_name])
+              end
+
+        raise 'Unable to find VDC - check your vdc_id or vdc_name' if vdc.nil?
+        vdc
       end
 
       def network
-        if config[:network_id]
-          org.networks.get(config[:network_id])
-        else
-          org.networks.get_by_name(config[:network_name])
-        end
+        network = if config[:network_id]
+                    org.networks.get(config[:network_id])
+                  else
+                    org.networks.get_by_name(config[:network_name])
+                  end
+
+        raise 'Unable to find network - check your network_id or network_name' if network.nil?
+        network
       end
 
       def node_description

--- a/spec/vcair_spec.rb
+++ b/spec/vcair_spec.rb
@@ -313,6 +313,7 @@ describe Kitchen::Driver::Vcair do
   describe '#image' do
     let(:catalog)       { double('catalog') }
     let(:catalog_items) { double('catalog_items') }
+    let(:image)         { double('image') }
 
     before do
       allow(driver).to receive(:catalog).and_return(catalog)
@@ -326,8 +327,8 @@ describe Kitchen::Driver::Vcair do
       end
 
       it 'fetches the catalog item by ID' do
-        expect(catalog_items).to receive(:get).with(1)
-        driver.image
+        expect(catalog_items).to receive(:get).with(1).and_return(image)
+        expect(driver.image).to eq(image)
       end
     end
 
@@ -338,8 +339,20 @@ describe Kitchen::Driver::Vcair do
       end
 
       it 'fetches the catalog item by name' do
-        expect(catalog_items).to receive(:get_by_name).with('image name')
-        driver.image
+        expect(catalog_items).to receive(:get_by_name).with('image name').and_return(image)
+        expect(driver.image).to eq(image)
+      end
+    end
+
+    context 'when no image is returned' do
+      before do
+        config[:image_id] = 1
+        config[:image_name] = nil
+      end
+
+      it 'raises an exception' do
+        expect(catalog_items).to receive(:get).with(1).and_return(nil)
+        expect { driver.image }.to raise_error(RuntimeError)
       end
     end
   end
@@ -347,6 +360,7 @@ describe Kitchen::Driver::Vcair do
   describe '#catalog' do
     let(:org)      { double('org') }
     let(:catalogs) { double('catalogs') }
+    let(:catalog)  { double('catalog') }
 
     before do
       allow(driver).to receive(:org).and_return(org)
@@ -360,8 +374,8 @@ describe Kitchen::Driver::Vcair do
       end
 
       it 'fetches the catalog by ID' do
-        expect(catalogs).to receive(:get).with(1)
-        driver.catalog
+        expect(catalogs).to receive(:get).with(1).and_return(catalog)
+        expect(driver.catalog).to eq(catalog)
       end
     end
 
@@ -372,8 +386,20 @@ describe Kitchen::Driver::Vcair do
       end
 
       it 'fetches the catalog by name' do
-        expect(catalogs).to receive(:get_by_name).with('catalog name')
-        driver.catalog
+        expect(catalogs).to receive(:get_by_name).with('catalog name').and_return(catalog)
+        expect(driver.catalog).to eq(catalog)
+      end
+    end
+
+    context 'when no catalog is returned' do
+      before do
+        config[:catalog_id] = 1
+        config[:catalog_name] = nil
+      end
+
+      it 'raises an exception' do
+        expect(catalogs).to receive(:get).with(1).and_return(nil)
+        expect { driver.catalog }.to raise_error(RuntimeError)
       end
     end
   end
@@ -381,6 +407,7 @@ describe Kitchen::Driver::Vcair do
   describe '#vdc' do
     let(:org)  { double('org') }
     let(:vdcs) { double('vdcs') }
+    let(:vdc)  { double('vdc') }
 
     before do
       allow(driver).to receive(:org).and_return(org)
@@ -394,8 +421,8 @@ describe Kitchen::Driver::Vcair do
       end
 
       it 'fetches the vdc by ID' do
-        expect(vdcs).to receive(:get).with(1)
-        driver.vdc
+        expect(vdcs).to receive(:get).with(1).and_return(vdc)
+        expect(driver.vdc).to eq(vdc)
       end
     end
 
@@ -406,8 +433,20 @@ describe Kitchen::Driver::Vcair do
       end
 
       it 'fetches the vdc by name' do
-        expect(vdcs).to receive(:get_by_name).with('vdc name')
-        driver.vdc
+        expect(vdcs).to receive(:get_by_name).with('vdc name').and_return(vdc)
+        expect(driver.vdc).to eq(vdc)
+      end
+    end
+
+    context 'when no vdc is returned' do
+      before do
+        config[:vdc_id] = 1
+        config[:vdc_name] = nil
+      end
+
+      it 'raises an exception' do
+        expect(vdcs).to receive(:get).with(1).and_return(nil)
+        expect { driver.vdc }.to raise_error(RuntimeError)
       end
     end
   end
@@ -415,6 +454,7 @@ describe Kitchen::Driver::Vcair do
   describe '#network' do
     let(:org)      { double('org') }
     let(:networks) { double('networks') }
+    let(:network)  { double('network') }
 
     before do
       allow(driver).to receive(:org).and_return(org)
@@ -428,8 +468,8 @@ describe Kitchen::Driver::Vcair do
       end
 
       it 'fetches the network by ID' do
-        expect(networks).to receive(:get).with(1)
-        driver.network
+        expect(networks).to receive(:get).with(1).and_return(network)
+        expect(driver.network).to eq(network)
       end
     end
 
@@ -440,8 +480,20 @@ describe Kitchen::Driver::Vcair do
       end
 
       it 'fetches the network by name' do
-        expect(networks).to receive(:get_by_name).with('network name')
-        driver.network
+        expect(networks).to receive(:get_by_name).with('network name').and_return(network)
+        expect(driver.network).to eq(network)
+      end
+    end
+
+    context 'when no network is returned' do
+      before do
+        config[:network_id] = 1
+        config[:network_name] = nil
+      end
+
+      it 'raises an exception' do
+        expect(networks).to receive(:get).with(1).and_return(nil)
+        expect { driver.network }.to raise_error(RuntimeError)
       end
     end
   end


### PR DESCRIPTION
When a network, vdc, catalog, or image was requested and did not
exist, a NoMethodError would be thrown when an action was taken
on the returned nil. This corrects that issue and provides better
exception messages so the user can debug their incorrect config.