### PR TITLE
Added vmapp_name attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp
 *.sw?
 *~
 .env.sh
+.idea

--- a/README.md
+++ b/README.md
@@ -67,10 +67,14 @@ platforms:
   - name: centos
     driver:
       catalog_name: Public Catalog
+      node_name: Linux-hostname
+      vmapp_name: VMapp-Linux
       image_name: CentOS64-64BIT
   - name: windows
     driver:
       catalog_name: Public Catalog
+      node_name: Windows-hostname
+      vmapp_name: VMapp-Windows
       image_name: W2K12-STD-R2-64BIT
       cpus: 2
       memory: 4096

--- a/lib/kitchen/driver/vcair.rb
+++ b/lib/kitchen/driver/vcair.rb
@@ -242,6 +242,10 @@ module Kitchen
         config[:node_name] || generate_node_name
       end
 
+      def vmapp_name
+        config[:vmapp_name] || generate_node_name
+      end
+
       def generate_node_name
         # SecureRandom.hex generates a string 2x the argument.
         # We need the name to be 15 chars or less to play nicely
@@ -305,7 +309,7 @@ module Kitchen
       end
 
       def instantiate
-        image.instantiate(node_name, instantiate_config)
+        image.instantiate(vmapp_name, instantiate_config)
       end
 
       def vapp


### PR DESCRIPTION
You can specify ```vmapp_name``` attribute, which will be added as VMapp name.
It may be useful for creation multiple VMs under one VMapp or VMs with the same 'computer_name' (```node_name```).
Updated README.md too.